### PR TITLE
Leaderboard improvements

### DIFF
--- a/native/stats.cpp
+++ b/native/stats.cpp
@@ -43,16 +43,16 @@ bool CallbackHandler::UploadScore(const std::string& leaderboardId, int score, i
 }
 
 
-static std::string toLeaderboardScore(const char* leaderboardName, int score, int detail, int rank){
+static std::string toLeaderboardScore(const char* leaderboardName, int score, int detail, int rank, std::string userName){
 	std::ostringstream data;
-	data << leaderboardName << "," << score << "," << detail << "," << rank;
+	data << leaderboardName << "," << score << "," << detail << "," << rank << "," << userName;
 	return data.str();
 }
 
 void CallbackHandler::OnScoreUploaded(LeaderboardScoreUploaded_t *pCallback, bool bIOFailure){
 	if (pCallback->m_bSuccess && !bIOFailure){
 		std::string leaderboardName = SteamUserStats()->GetLeaderboardName(pCallback->m_hSteamLeaderboard);
-		std::string data = toLeaderboardScore(SteamUserStats()->GetLeaderboardName(pCallback->m_hSteamLeaderboard), pCallback->m_nScore, -1, pCallback->m_nGlobalRankNew);
+		std::string data = toLeaderboardScore(SteamUserStats()->GetLeaderboardName(pCallback->m_hSteamLeaderboard), pCallback->m_nScore, -1, pCallback->m_nGlobalRankNew, "");
 		SendEvent(ScoreUploaded, true, data.c_str());
 	}else if (pCallback != NULL && pCallback->m_hSteamLeaderboard != 0) {
 		SendEvent(ScoreUploaded, false, SteamUserStats()->GetLeaderboardName(pCallback->m_hSteamLeaderboard));
@@ -95,14 +95,17 @@ void CallbackHandler::OnScoreDownloaded(LeaderboardScoresDownloaded_t *pCallback
 
 		if (haveData)
 			data << ";";
-		data << toLeaderboardScore(leaderboardId.c_str(), entry.m_nScore, details[0], entry.m_nGlobalRank).c_str();
+
+		std::string userName = SteamFriends()->GetFriendPersonaName(entry.m_steamIDUser);
+
+		data << toLeaderboardScore(leaderboardId.c_str(), entry.m_nScore, details[0], entry.m_nGlobalRank, userName).c_str();
 		haveData = true;
 	}
 
 	if (haveData)
 		SendEvent(ScoreDownloaded, true, data.str().c_str());
 	else
-		SendEvent(ScoreDownloaded, true, toLeaderboardScore(leaderboardId.c_str(), -1, -1, -1).c_str());
+		SendEvent(ScoreDownloaded, true, toLeaderboardScore(leaderboardId.c_str(), -1, -1, -1, "").c_str());
 }
 
 void CallbackHandler::RequestGlobalStats(){


### PR DESCRIPTION
Added ability to specify how many records before and after the user to download which is how the Steam API is intended to be used. It was hardcoded to 0 and thus only returning your own record and no one else.

Plus added username to the leaderboard score record so now when we can't download scores for not just the immediate user we know which one is our and which one are someone else and what they are called.